### PR TITLE
support multiple regions

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "aws_profile" {
+  description = "Which AWS profile is should be used? Defaults to \"default\""
+  default     = "default"
+}
+
 variable "allowed_cidr" {
   type        = "list"
   default     = ["0.0.0.0/0"]


### PR DESCRIPTION
This uses an aliased aws provider to allow instantiating multiple instances of this module in different regions.